### PR TITLE
Fix race condition during SSR

### DIFF
--- a/ProsemirrorEditor.svelte
+++ b/ProsemirrorEditor.svelte
@@ -100,7 +100,7 @@
   })
 
   onDestroy(() => {
-    view.destroy()
+    view && view.destroy()
   })
 
 </script>


### PR DESCRIPTION
Said error:
```
Cannot read properties of null (reading 'destroy')
TypeError: Cannot read properties of null (reading 'destroy')
    at ProsemirrorEditor.svelte:103:9
```